### PR TITLE
chore: description added to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "handtrack-rs"
 version = "0.1.0"
+description = "A library for hand detection."
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
closes #10.